### PR TITLE
opti Date.getTime

### DIFF
--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -12,7 +12,7 @@ export default function throttle(callback, delay, type) {
       newDelay = context.duration > 1000 ? delay : context.duration / 10;
     }
 
-    const now = +new Date();
+    const now = (new Date()).getTime();
     // eslint-disable-next-line prefer-rest-params
     const args = arguments;
     if (last && now < last + newDelay) {


### PR DESCRIPTION
a little optimisation for more readability and performance.

[jsperf](https://jsperf.com/get-time-vs-unary-plus/7)